### PR TITLE
added requirements.txt

### DIFF
--- a/python3/requirements.txt
+++ b/python3/requirements.txt
@@ -1,0 +1,1 @@
+pycryptodome


### PR DESCRIPTION
Hi,
I've added the [requirements.txt](https://pip.readthedocs.io/en/1.1/requirements.html) file with the pycryptodome dependency.

I haven't updated the documentation but to use this file, as stated on the documentation, you just need to execute pip like this:

```console
pip install -r requirements.txt
```
kind regards,